### PR TITLE
Allow clicking on song links as well as the song page.

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,8 +8,11 @@ browser.contextMenus.create({
 
 browser.contextMenus.onClicked.addListener(function(info, tab) {
     if (info.menuItemId == menuId) {
-        browser.tabs.executeScript({
-            file: "detektor.js"
+        var code = "var linkUrl = '" + (info.linkUrl || 'document.location.href') + "';";
+        browser.tabs.executeScript({ code: code }, function() {
+            browser.tabs.executeScript({
+                file: "detektor.js"
+            });
         });
     }
 });
@@ -72,6 +75,7 @@ channel.on("keyFound", track => {
         }
         var newPlaylist = _.without(playlist, oldTrack);
         oldTrack.key = track.key;
+        if(track.title) { oldTrack.title = track.title };
         newPlaylist.push(oldTrack);
         storage.set({"playlist": newPlaylist});
     })

--- a/detektor.js
+++ b/detektor.js
@@ -12,8 +12,11 @@ var title = function () {
     return pieces.join("-");
 }()
 
+// linkUrl should be defined in javascript injection via background.js
+if(typeof linkUrl == 'undefined') { console.log('Something went wrong with context menu callback! linkUrl is not defined!') }
+
 port.postMessage({
     action: 'addToPlaylist',
     title: title,
-    url: document.location.href
+    url: linkUrl
 });


### PR DESCRIPTION
Song titles will be fired from the server (parsed from the youtube-dl output). We will also generate the song url by looking for the `info.linkUrl` in the contextMenu click event before defaulting to `document.location.href`.
Backend story: https://github.com/alan-andrade/detektor-backend/pull/1
Seems to work! 

![screen shot 2016-12-11 at 7 12 37 pm](https://cloud.githubusercontent.com/assets/6475614/21086936/e953d4de-bfd5-11e6-9d96-d309241de7e5.png)
